### PR TITLE
Fix typographical errors in Awards section

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,9 +204,9 @@
       </section>
 	  <section id="awards">
 		<h1>Awards</h1>
-		<h4>Consortium for Mathematics and it's Applications</h4>
+                <h4>Consortium for Mathematics and Its Applications</h4>
 		<p>
-			In Spring of 2019 at Wintrhop University, 2 of my colleagues and I participated in the Consortium for Mathematics and it's Applications. COMAP's Mathematical Contest in Modeling (MCM) is an international contest for high school students and college undergraduates. It challenges teams of students to clarify, analyze, and propose solutions to open-ended problems. The contest attracts diverse students and faculty advisors from over 900 institutions around the world.
+                        In Spring of 2019 at Winthrop University, 2 of my colleagues and I participated in the Consortium for Mathematics and its Applications. COMAP's Mathematical Contest in Modeling (MCM) is an international contest for high school students and college undergraduates. It challenges teams of students to clarify, analyze, and propose solutions to open-ended problems. The contest attracts diverse students and faculty advisors from over 900 institutions around the world.
 		</p>
 		<p>
 			Our team chose problem statement C, title <a href="http://www.mathmodels.org/Problems/2019/MCM-C/index.html" target="_blank">The Opioid Crisis</a>, a Big Data problem. After applying some Machine Learning to the given dataset, we discovered a few interesting correlations. One of which was that the amount of Opioid Cases for a state increased as the amount of children under 18 who live with their grandparents increased. After developing a mathematical model for the problem, we generated a 25 page report and predicted that opioid cases will slightly go down in the near future.


### PR DESCRIPTION
## Summary
- Corrected COMAP organization name to use proper possessive "Its"
- Fixed spelling of "Winthrop University" and adjusted possessive "its" in Awards paragraph

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68994b585de08328bdeefd20594fb273