### PR TITLE
Add Jest test for navList utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-My personal [website](https://dbranham20.github.io/) showcasing my professional achievements and personal projects 
+My personal [website](https://dbranham20.github.io/) showcasing my professional achievements and personal projects
+
+## Tests
+
+Run unit tests with [Jest](https://jestjs.io/):
+
+```
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dbranham20.github.io",
+  "version": "1.0.0",
+  "description": "My personal [website](https://dbranham20.github.io/) showcasing my professional achievements and personal projects",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0",
+    "jquery": "^3.7.1"
+  }
+}

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -1,0 +1,40 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+describe('navList', () => {
+  test('produces links with depth classes based on nesting', () => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const { window } = dom;
+    const $ = require('jquery')(window);
+
+    global.window = window;
+    global.document = window.document;
+    global.$ = $;
+    global.jQuery = $;
+
+    require(path.resolve(__dirname, '../assets/js/util.js'));
+
+    const $nav = $(
+      `<nav>
+        <ul>
+          <li><a href="#home">Home</a></li>
+          <li>
+            <a href="#about">About</a>
+            <ul>
+              <li><a href="#team">Team</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>`
+    );
+
+    const result = $nav.navList();
+    const frag = JSDOM.fragment(result);
+    const links = frag.querySelectorAll('a');
+
+    expect(links.length).toBe(3);
+    expect(links[0].classList.contains('depth-0')).toBe(true);
+    expect(links[1].classList.contains('depth-0')).toBe(true);
+    expect(links[2].classList.contains('depth-1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add JSDOM-based unit test that verifies navList emits depth classes
- document how to run tests in README
- add package.json and gitignore for testing setup

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68994b93dcfc8328b1f2c755011933cb