### PR TITLE
Remove obsolete poptrox gallery call

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -93,25 +93,4 @@
 
 			}
 
-	// Main Sections: Two.
-
-		// Lightbox gallery.
-			$window.on('load', function() {
-
-				$('#two').poptrox({
-					caption: function($a) { return $a.next('h3').text(); },
-					overlayColor: '#2c2c2c',
-					overlayOpacity: 0.85,
-					popupCloserText: '',
-					popupLoaderText: '',
-					selector: '.work-item a.image',
-					usePopupCaption: true,
-					usePopupDefaultStyling: false,
-					usePopupEasyClose: false,
-					usePopupNav: true,
-					windowMargin: (breakpoints.active('<=small') ? 0 : 50)
-				});
-
-			});
-
 })(jQuery);


### PR DESCRIPTION
## Summary
- drop unused poptrox gallery initialization that referenced non-existent `#two` section

## Testing
- `npx -p puppeteer@latest node -e "console.log('browser test')"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68994b8e51fc8328854f7c3a3c470671